### PR TITLE
reconcile get_feature_names.ranger error message with test regexp

### DIFF
--- a/R/get_feature_names.R
+++ b/R/get_feature_names.R
@@ -104,7 +104,7 @@ get_feature_names.ranger <- function(object, ...) {
     names(object$variable.importance)
   } else {
     stop("Unable to recover feature names from ranger models with `importance",
-         " = \"none\"`` and `write.forest = FALSE`.")
+         " = \"none\"` and `write.forest = FALSE`.")
   }
 }
 

--- a/tests/testthat/test_get_feature_names.R
+++ b/tests/testthat/test_get_feature_names.R
@@ -102,7 +102,7 @@ test_that("get_feature_names() works for \"ranger\" objects", {
                                  importance = "none",
                                  write.forest = FALSE)
   expect_error(get_feature_names(ranger_model),
-               regexp = paste("^Unable to recover feature names from ranger",
-                              "model with importance = \"none\" and write.forest = FALSE.$"))
+               regexp = paste("^Unable to recover feature names from ranger models",
+                              "with `importance = \"none\"` and `write.forest = FALSE`.$"))
 
 })


### PR DESCRIPTION
Updated the regexp in the test to match the new error message (backticks, etc.) and fix the broken test [here](https://github.com/koalaverse/vip/blob/facb27d4ba21b59cc63c943b8a4326d31553578b/tests/testthat/test_get_feature_names.R#L105).