### PR TITLE
fix vi method for parsnip

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -2,7 +2,7 @@
 
 S3method(add_sparklines,vi)
 S3method(vi,default)
-S3method(vi,model_spec)
+S3method(vi,model_fit)
 S3method(vi_ice,default)
 S3method(vi_model,C5.0)
 S3method(vi_model,H2OBinomialModel)

--- a/R/vi.R
+++ b/R/vi.R
@@ -171,6 +171,6 @@ vi.default <- function(
 #' @rdname vi
 #'
 #' @export
-vi.model_spec <- function(object, ...) {
+vi.model_fit <- function(object, ...) {
   vi(object$fit, ...)
 }

--- a/man/vi.Rd
+++ b/man/vi.Rd
@@ -3,7 +3,7 @@
 \name{vi}
 \alias{vi}
 \alias{vi.default}
-\alias{vi.model_spec}
+\alias{vi.model_fit}
 \title{Variable importance}
 \usage{
 vi(object, ...)
@@ -13,7 +13,7 @@ vi(object, ...)
   abbreviate_feature_names = NULL, sort = TRUE, decreasing = TRUE,
   scale = FALSE, rank = FALSE, ...)
 
-\method{vi}{model_spec}(object, ...)
+\method{vi}{model_fit}(object, ...)
 }
 \arguments{
 \item{object}{A fitted model object (e.g., a \code{"randomForest"} object) or

--- a/tests/testthat/test_vi_ice.R
+++ b/tests/testthat/test_vi_ice.R
@@ -37,7 +37,7 @@ test_that("`vi_ice()` works with parsnip objects", {
   ice_vi <- vi(lm_mod, method = "ice")
 
   parsnip <- list(fit = lm_mod)
-  class(parsnip) <- c("linear_reg", "model_spec")
+  class(parsnip) <- c("linear_reg", "model_fit")
   expect_equal(ice_vi, vi(parsnip, method = "ice"))
 })
 

--- a/tests/testthat/test_vi_model.R
+++ b/tests/testthat/test_vi_model.R
@@ -772,7 +772,7 @@ test_that("`vi_model()` works with parsnip objects", {
   mod_vi <- vi(lm_mod)
 
   parsnip <- list(fit = lm_mod)
-  class(parsnip) <- c("linear_reg", "model_spec")
+  class(parsnip) <- c("linear_reg", "model_fit")
   expect_equal(mod_vi, vi(parsnip))
 })
 

--- a/tests/testthat/test_vi_pdp.R
+++ b/tests/testthat/test_vi_pdp.R
@@ -38,7 +38,7 @@ test_that("`vi_pdp()` works with parsnip objects", {
   pdp_vi <- vi(lm_mod, method = "pdp")
 
   parsnip <- list(fit = lm_mod)
-  class(parsnip) <- c("linear_reg", "model_spec")
+  class(parsnip) <- c("linear_reg", "model_fit")
   expect_equal(pdp_vi, vi(parsnip, method = "pdp"))
 
 })


### PR DESCRIPTION
Currently, `vi`'s method  for parsnip is `vi.model_spec`.
However, fitted object has the class `model_fit`.
Thus, `vi.model_fit` is the correct one to implement.

https://tidymodels.github.io/parsnip/reference/fit.html#value