### PR TITLE
Refactor: fixes use of deprecated as.tibble

### DIFF
--- a/R/vi_model.R
+++ b/R/vi_model.R
@@ -529,7 +529,7 @@ vi_model.cv.glmnet <- function(object, ...) {
 vi_model.H2OBinomialModel <- function(object, ...) {
 
   # Construct model-specific variable importance scores
-  tib <- tibble::as.tibble(h2o::h2o.varimp(object))
+  tib <- tibble::as_tibble(h2o::h2o.varimp(object))
   if (object@algorithm == "glm") {
     names(tib) <- c("Variable", "Importance", "Sign")
     # FIXME: Extra row at the bottom?
@@ -556,7 +556,7 @@ vi_model.H2OBinomialModel <- function(object, ...) {
 vi_model.H2OMultinomialModel <- function(object, ...) {
 
   # Construct model-specific variable importance scores
-  tib <- tibble::as.tibble(h2o::h2o.varimp(object))
+  tib <- tibble::as_tibble(h2o::h2o.varimp(object))
   if (object@algorithm == "glm") {
     names(tib) <- c("Variable", "Importance", "Sign")
     # FIXME: Extra row at the bottom?
@@ -583,7 +583,7 @@ vi_model.H2OMultinomialModel <- function(object, ...) {
 vi_model.H2ORegressionModel <- function(object, ...) {
 
   # Construct model-specific variable importance scores
-  tib <- tibble::as.tibble(h2o::h2o.varimp(object))
+  tib <- tibble::as_tibble(h2o::h2o.varimp(object))
   if (object@algorithm == "glm") {
     names(tib) <- c("Variable", "Importance", "Sign")
     # FIXME: Extra row at the bottom?
@@ -1319,7 +1319,7 @@ vi_model.xgb.Booster <- function(object, type = c("gain", "cover", "frequency"),
   if ("weight" %in% names(imp)) {
     type <- "weight"  # gblinear
   }
-  vis <- tibble::as.tibble(imp)[, c("feature", type)]
+  vis <- tibble::as_tibble(imp)[, c("feature", type)]
   tib <- tibble::tibble(
     "Variable" = vis$feature,
     "Importance" = vis[[2L]]

--- a/R/vi_permute.R
+++ b/R/vi_permute.R
@@ -111,7 +111,7 @@
 #' trn <- gen_friedman(500, seed = 101)  # ?vip::gen_friedman
 #'
 #' # Inspect data
-#' tibble::as.tibble(trn)
+#' tibble::as_tibble(trn)
 #'
 #' # Fit PPR and NN models (hyperparameters were chosen using the caret package
 #' # with 5 repeats of 5-fold cross-validation)

--- a/R/vint.R
+++ b/R/vint.R
@@ -99,5 +99,5 @@ vint <- function(object, feature_names, progress = "none", parallel = FALSE,
     "Interaction" = ints
   )
   ints <- ints[order(ints["Interaction"], decreasing = TRUE), ]
-  tibble::as.tibble(ints)
+  tibble::as_tibble(ints)
 }

--- a/man/vi_permute.Rd
+++ b/man/vi_permute.Rd
@@ -140,7 +140,7 @@ library(nnet)     # for fitting neural networks
 trn <- gen_friedman(500, seed = 101)  # ?vip::gen_friedman
 
 # Inspect data
-tibble::as.tibble(trn)
+tibble::as_tibble(trn)
 
 # Fit PPR and NN models (hyperparameters were chosen using the caret package
 # with 5 repeats of 5-fold cross-validation)

--- a/vignettes/vip.Rmd
+++ b/vignettes/vip.Rmd
@@ -41,7 +41,7 @@ For illustration, we use one of the regression problems described in Friedman (1
 trn <- gen_friedman(500, seed = 101)  # ?vip::gen_friedman
 
 # Inspect data
-tibble::as.tibble(trn)
+tibble::as_tibble(trn)
 ```
 
 


### PR DESCRIPTION
Updates all uses of the deprecated `as.tibble` to `as_tibble`, including uses in docs (i.e. function docs & vignettes).

Ref #101 