### PR TITLE
Allow `newx` argument with `glmnet`

### DIFF
--- a/R/vi_permute.R
+++ b/R/vi_permute.R
@@ -336,10 +336,17 @@ vi_permute.default <- function(
   }
 
   # Compute baseline metric for comparison
-  baseline <- mfun(
-    actual = train_y,
-    predicted = pred_wrapper(object, newdata = train_x)
-  )
+  if (all(grepl('glmnet', class(object)))) {
+    baseline <- mfun(
+      actual = train_y,
+      predicted = pred_wrapper(object, newx = train_x)
+    )
+  } else {
+    baseline <- mfun(
+      actual = train_y,
+      predicted = pred_wrapper(object, newdata = train_x)
+    )
+  }
 
   # Type of comparison
   type <- match.arg(type)
@@ -372,10 +379,19 @@ vi_permute.default <- function(
         # train_x_permuted <- train_x  # make copy
         # train_x_permuted[[x]] <- sample(train_x_permuted[[x]])  # permute values
         train_x_permuted <- permute_columns(train_x, columns = x)
-        permuted <- mfun(
-          actual = train_y,
-          predicted = pred_wrapper(object, newdata = train_x_permuted)
-        )
+
+        if (all(grepl('glmnet', class(object)))) {
+          permuted <- mfun(
+            actual = train_y,
+            predicted = pred_wrapper(object, newx = train_x_permuted)
+          )
+        } else {
+          permuted <- mfun(
+            actual = train_y,
+            predicted = pred_wrapper(object, newdata = train_x_permuted)
+          )
+        }
+
         if (smaller_is_better) {
           permuted %compare% baseline  # e.g., RMSE
         } else {


### PR DESCRIPTION
As far as I can tell, there's no way around the following issue (let me know if I'm wrong and am missing something!):

``` r
library(vip)
#> 
#> Attaching package: 'vip'
#> The following object is masked from 'package:utils':
#> 
#>     vi
library(glmnet)
#> Loading required package: Matrix
#> Loaded glmnet 4.0-2
library(tidyverse)

df <- iris %>%
  filter(Species != 'setosa') %>%
  mutate(versicolor = Species == 'versicolor')

X <- df %>%
  select(-Species, -versicolor) %>%
  as.matrix()

Y <- df$versicolor %>%
  as.factor()

mod <- glmnet(x = X, y = Y, family = binomial(), lambda = .01)

vip(
  mod,
  method = 'permute',
  train = X,
  target = Y,
  metric = 'auc',
  pred_wrapper = predict,
  reference_class = 'TRUE'
)
#> Error in predict.glmnet(object, newdata = train_x): You need to supply a value for 'newx'
```

<sup>Created on 2021-05-24 by the [reprex package](https://reprex.tidyverse.org) (v1.0.0)</sup>

This PR is just a patch / suggestion, and I'm sure there's a way cleaner way to accomplish this. With my fix:

``` r
library(vip)
#> 
#> Attaching package: 'vip'
#> The following object is masked from 'package:utils':
#> 
#>     vi
library(glmnet)
#> Loading required package: Matrix
#> Loaded glmnet 4.0-2
library(tidyverse)

df <- iris %>%
  filter(Species != 'setosa') %>%
  mutate(versicolor = Species == 'versicolor')

X <- df %>%
  select(-Species, -versicolor) %>%
  as.matrix()

Y <- df$versicolor %>%
  as.factor()

mod <- glmnet(x = X, y = Y, family = binomial(), lambda = .01)

vip(
  mod,
  method = 'permute',
  train = X,
  target = Y,
  metric = 'auc',
  pred_wrapper = predict,
  reference_class = 'TRUE'
)
```

![](https://i.imgur.com/V3LQ6vH.png)

<sup>Created on 2021-05-24 by the [reprex package](https://reprex.tidyverse.org) (v1.0.0)</sup>

I'd be happy to work more on a cleaner solution here. I'm sure that other model implementations run into similar issues (presumably `xgboost` since it takes a matrix, `ranger` maybe, etc.). I think the cleanest way to solve this might be with `...` instead of `train` in `vip()`, where you could pass `newx = X`, etc. That way `glmnet` or whatever other package is doing the modeling would throw an error like the one above and we could add a helpful hint like "specify `vip(newx = X)`"